### PR TITLE
variable name mixed error and bug fixed

### DIFF
--- a/R/HoneyBADGER.R
+++ b/R/HoneyBADGER.R
@@ -1697,7 +1697,7 @@ HoneyBADGER$methods(
         I.j <- unlist(lapply(genes2snps.dict, length))
         numGenes <- length(genes2snps.dict)
         numSnpsPerGene <- max(I.j)
-        numCells <- ncol(r)
+        numCells <- ncol(r.maf)
         ## j, i, k
         r.array <- array(0, c(numGenes, numSnpsPerGene, numCells))
         for(i in seq_len(numGenes)) {
@@ -1737,7 +1737,7 @@ HoneyBADGER$methods(
             'n.bulk' = n.bulk.array,
             'n.sc' = n.sc.array,
             'J' = length(I.j),  # how many genes
-            'K' = ncol(r),  # how many cells
+            'K' = ncol(r.maf),  # how many cells
             'I.j' = I.j,
             'pseudo' = pe,
             'mono' = mono,

--- a/R/HoneyBADGER.R
+++ b/R/HoneyBADGER.R
@@ -118,8 +118,10 @@ HoneyBADGER <- setRefClass(
 #' hb <- HoneyBADGER$new()
 #' hb$setGexpMats(gexp, ref, mart.obj, filter=FALSE, scale=FALSE)
 #'
+# minMeanBoth=0, minMeanTest=mean(gexp.sc.init[gexp.sc.init!=0]), minMeanRef=mean(gexp.ref.init[gexp.ref.init!=0]),
+# minMeanBoth=4.5, minMeanTest=6, minMeanRef=8,
 HoneyBADGER$methods(
-    setGexpMats=function(gexp.sc.init, gexp.ref.init, mart.obj, filter=TRUE, minMeanBoth=4.5, minMeanTest=6, minMeanRef=8, scale=TRUE, id="hgnc_symbol", verbose=TRUE) {
+    setGexpMats=function(gexp.sc.init, gexp.ref.init, mart.obj, filter=TRUE, minMeanBoth=0, minMeanTest=mean(gexp.sc.init[gexp.sc.init!=0]), minMeanRef=mean(gexp.ref.init[gexp.ref.init!=0]), scale=TRUE, id="hgnc_symbol", verbose=TRUE) {
         if(verbose) {
           cat("Initializing expression matrices ... \n")
         }

--- a/R/HoneyBADGER.R
+++ b/R/HoneyBADGER.R
@@ -1857,9 +1857,9 @@ HoneyBADGER$methods(
             gr <- range(genes[unlist(bound.genes.final),])
             sr <- range(snps[unlist(bound.snps.final),])
             if(intersect) {
-                rgs <- intersect(gr, sr)
+                rgs <- GenomicRanges::intersect(gr, sr)
             } else {
-                rgs <- union(gr, sr)
+                rgs <- GenomicRanges::union(gr, sr)
             }
 
             retest <- lapply(seq_len(length(rgs)), function(i) {

--- a/R/HoneyBADGER_comb.R
+++ b/R/HoneyBADGER_comb.R
@@ -106,7 +106,7 @@ calcCombCnvProb=function(gexp.norm, genes, mvFit, m=0.15, r.maf, n.sc, l.maf, n.
   I.j <- unlist(lapply(genes2snps.dict, length))
   numGenes <- length(genes2snps.dict)
   numSnpsPerGene <- max(I.j)
-  numCells <- ncol(r)
+  numCells <- ncol(r.maf)
   ## j, i, k
   r.array <- array(0, c(numGenes, numSnpsPerGene, numCells))
   for(i in seq_len(numGenes)) {

--- a/R/HoneyBADGER_comb.R
+++ b/R/HoneyBADGER_comb.R
@@ -106,7 +106,7 @@ calcCombCnvProb=function(gexp.norm, genes, mvFit, m=0.15, r.maf, n.sc, l.maf, n.
   I.j <- unlist(lapply(genes2snps.dict, length))
   numGenes <- length(genes2snps.dict)
   numSnpsPerGene <- max(I.j)
-  numCells <- ncol(r.maf)
+  numCells <- ncol(r.maf)## original name error --Rongting
   ## j, i, k
   r.array <- array(0, c(numGenes, numSnpsPerGene, numCells))
   for(i in seq_len(numGenes)) {
@@ -146,7 +146,7 @@ calcCombCnvProb=function(gexp.norm, genes, mvFit, m=0.15, r.maf, n.sc, l.maf, n.
     'n.bulk' = n.bulk.array,
     'n.sc' = n.sc.array,
     'J' = length(I.j),  # how many genes
-    'K' = ncol(r),  # how many cells
+    'K' = ncol(r.maf),  # how many cells # name error Rongting
     'I.j' = I.j,
     'pseudo' = pe,
     'mono' = mono,

--- a/R/HoneyBADGER_gexp.R
+++ b/R/HoneyBADGER_gexp.R
@@ -92,7 +92,7 @@ setGexpMats=function(gexp.sc.init, gexp.ref.init, mart.obj, filter=TRUE, minMean
         return(
             list(
                 gexp.sc = gexp.sc,
-                gexp.red = gexp.ref,
+                gexp.ref = gexp.ref,
                 gexp.norm = gexp.norm,
                 genes = genes
             )

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -31,7 +31,9 @@ data(ref) ## reference
 
 require(biomaRt) ## for gene coordinates
 #mart.obj <- useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = 'hsapiens_gene_ensembl', host = "jul2015.archive.ensembl.org") ## version used in manuscript
-mart.obj <- useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = 'hsapiens_gene_ensembl') ## current version
+mart.obj <- useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = 'hsapiens_gene_ensembl') ## current version 20210603- default version hg38
+
+mart.obj <- useMart(biomart="ENSEMBL_MART_ENSEMBL", host="grch37.ensembl.org", dataset="hsapiens_gene_ensembl") # specify the version hg19
 
 print(gexp[1:5,1:5])
 ```


### PR DESCRIPTION
(1) HoneyBADGER.R  method setGexpMats update (according to the issues)
(2) calcCombCnvProb method--variable name mixed error!
r is the built-in dataset in HoneyBADGER. once you library the package, r is the global variable in the environment.
then we just use the built-in dataset but not the users' dataset
(3) other name errors
(4) tutorial update